### PR TITLE
fix meson build script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -191,6 +191,8 @@ if enable_tests
   else
     add_global_arguments('-DFIU_ENABLE', language: 'c')
   endif
+else
+  libfiu_dep = disabler()
 endif
 
 #######################


### PR DESCRIPTION
The build fails when not building tests:
```
Message: Tests: false
Message:
Run-time dependency threads found: YES

meson.build:283:34: ERROR: Unknown variable "libfiu_dep".
```
This fixes it.